### PR TITLE
Fix indication of which key to use

### DIFF
--- a/docs/HOW_TO_MANAGE_SECRETS.md
+++ b/docs/HOW_TO_MANAGE_SECRETS.md
@@ -121,7 +121,7 @@ Then create a second entry called `keygrip` which must contain the keygrip of yo
 With the output above it should be:
 
 ```
-n/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+n/YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
 ```
 
 And you're done ! The pinentry program won't ask for your password anymore, as long as your KeePassXC database is unlocked.


### PR DESCRIPTION
I was following this guide and, at least for me, the correct key to use was "Y" and non "Z".

I don't know if this is just specific to my setup or maybe to the type of key that i'm using.